### PR TITLE
Compose publication source line and collapse single-date experience ranges

### DIFF
--- a/ahmadstyle/ExperienceEntry.j2.typ
+++ b/ahmadstyle/ExperienceEntry.j2.typ
@@ -20,7 +20,11 @@
 {% set formatted_end = format_date(entry.end_date) %}
 {% set company_date_range = "" %}
 {% if formatted_start and formatted_end %}
+  {% if formatted_start == formatted_end %}
+  {% set company_date_range = formatted_start %}
+  {% else %}
   {% set company_date_range = formatted_start + " – " + formatted_end %}
+  {% endif %}
 {% elif formatted_start %}
   {% set company_date_range = formatted_start %}
 {% elif formatted_end %}

--- a/ahmadstyle/PublicationEntry.j2.typ
+++ b/ahmadstyle/PublicationEntry.j2.typ
@@ -19,20 +19,32 @@
 
   v(design_publication_after_title)
 
+  {% set vip = "" %}
+  {% if entry.volume %}{% set vip = vip ~ entry.volume %}{% endif %}
+  {% if entry.issue %}{% set vip = vip ~ "(" ~ entry.issue ~ ")" %}{% endif %}
+  {% if entry.pages %}{% set vip = (vip ~ ", " if vip else "") ~ entry.pages %}{% endif %}
+  {% if entry.journal %}{% set source = entry.journal ~ (", " ~ vip if vip else "") %}
+  {% elif entry.institution %}{% set source = (entry.type ~ ", " if entry.type else "") ~ entry.institution %}
+  {% elif entry.publisher %}{% set source = entry.publisher ~ (", " ~ vip if vip else "") %}
+  {% else %}{% set source = "" %}{% endif %}
+  {% if source %}
   grid(
     columns: (1fr, auto),
     align: (left, right),
-    text(style: "italic", "{{ entry.journal|replace('\\(', '(')|replace('\\)', ')') }}"),
+    text(style: "italic", "{{ source|replace('\\(', '(')|replace('\\)', ')') }}"),
     ""
   )
 
   v(design_publication_after_journal)
+  {% endif %}
 
   [{{ entry.authors|join(', ') }}];
 
+  {% if entry.doi %}
   v(design_publication_after_authors);
 
   [DOI: {{ entry.doi }}]
+  {% endif %}
 })
 
 #v(design_publication_spacing)

--- a/ahmadstyle/entries/ExperienceEntry.j2.typ
+++ b/ahmadstyle/entries/ExperienceEntry.j2.typ
@@ -20,7 +20,11 @@
 {% set formatted_end = format_date(entry.end_date) %}
 {% set company_date_range = "" %}
 {% if formatted_start and formatted_end %}
+  {% if formatted_start == formatted_end %}
+  {% set company_date_range = formatted_start %}
+  {% else %}
   {% set company_date_range = formatted_start + " – " + formatted_end %}
+  {% endif %}
 {% elif formatted_start %}
   {% set company_date_range = formatted_start %}
 {% elif formatted_end %}

--- a/ahmadstyle/entries/PublicationEntry.j2.typ
+++ b/ahmadstyle/entries/PublicationEntry.j2.typ
@@ -19,21 +19,32 @@
 
   v(design_publication_after_title)
 
+  {% set vip = "" %}
+  {% if entry.volume %}{% set vip = vip ~ entry.volume %}{% endif %}
+  {% if entry.issue %}{% set vip = vip ~ "(" ~ entry.issue ~ ")" %}{% endif %}
+  {% if entry.pages %}{% set vip = (vip ~ ", " if vip else "") ~ entry.pages %}{% endif %}
+  {% if entry.journal %}{% set source = entry.journal ~ (", " ~ vip if vip else "") %}
+  {% elif entry.institution %}{% set source = (entry.type ~ ", " if entry.type else "") ~ entry.institution %}
+  {% elif entry.publisher %}{% set source = entry.publisher ~ (", " ~ vip if vip else "") %}
+  {% else %}{% set source = "" %}{% endif %}
+  {% if source %}
   grid(
     columns: (1fr, auto),
     align: (left, right),
-    text(style: "italic", "{{ entry.journal|replace('\\(', '(')|replace('\\)', ')') }}"),
+    text(style: "italic", "{{ source|replace('\\(', '(')|replace('\\)', ')') }}"),
     ""
   )
 
   v(design_publication_after_journal)
+  {% endif %}
 
   [{{ entry.authors|join(', ') }}];
 
+  {% if entry.doi %}
   v(design_publication_after_authors);
 
   [DOI: {{ entry.doi }}]
+  {% endif %}
 })
 
 #v(design_publication_spacing)
-#v(design-entries-vertical-space-between-entries)


### PR DESCRIPTION
PublicationEntry now builds the italic source line from journal plus
volume/issue/pages (with institution/type and publisher fallbacks for
non-journal works), hides the source line when no source is available,
and only emits the DOI line when a DOI is present. ExperienceEntry shows
a single date instead of "X – X" when start and end dates are equal.
Applied to both the root and entries/ theme copies to stay in sync.

https://claude.ai/code/session_01Rx6BPU58MHiwJgeuVPPtzQ