### PR TITLE
Fix resume entry field type coercion for rendercv 2.8

### DIFF
--- a/resume_builder/build_clean.py
+++ b/resume_builder/build_clean.py
@@ -302,10 +302,17 @@ def subfilter(
         print(f"  Skipping entry due to tags: {required_tags}")
         return None
 
-    if required_tags:
-        entry = entry.copy()
-        entry.pop("tags", None)
-
+    entry = entry.copy()
+    entry.pop("tags", None)
+    entry.pop("itags", None)
+    # rendercv 2.8's templater runs str ops on every entry field; coerce
+    # non-string scalars so values like `number_of_students: 32` don't crash
+    # with `TypeError: expected string or bytes-like object`.
+    for field_name, field_value in list(entry.items()):
+        if isinstance(field_value, bool) or not isinstance(
+            field_value, (str, list, dict, type(None))
+        ):
+            entry[field_name] = str(field_value)
     return entry
 
 


### PR DESCRIPTION
## Summary
Updated the `subfilter` function to properly handle non-string scalar fields in resume entries, ensuring compatibility with rendercv 2.8's templater which performs string operations on all entry fields.

## Key Changes
- Moved entry copying and tag removal outside the conditional block to always occur
- Added removal of `itags` field in addition to `tags`
- Implemented type coercion for non-string scalar values (numbers, booleans, etc.) by converting them to strings before template rendering
- This prevents `TypeError` exceptions when the templater attempts string operations on numeric or boolean fields

## Implementation Details
The fix iterates through all entry fields and converts any non-string, non-collection types (excluding `None`) to strings. This ensures that fields like `number_of_students: 32` are safely handled by rendercv 2.8's templater without crashing.

https://claude.ai/code/session_01189NVtut9BgHfvmUAC74B2